### PR TITLE
Added support for Paquette style shorthand

### DIFF
--- a/pressgloss/__main__.py
+++ b/pressgloss/__main__.py
@@ -23,6 +23,7 @@ from . import create_app
 
 # python -m pressgloss --operation translate --daide "FRM (ENG) (FRA ITA) (PRP (PCE (FRA ITA)))" --tones "Haughty,Urgent"
 # python -m pressgloss --operation translate --daide "FRM (ENG) (FRA ITA) (PRP (PCE (FRA ITA)))" --tones "Objective"
+# python -m pressgloss --operation translate --daide "FRM (FRA) (ENG) (PRP (XDO ((ENG AMY LVP) MTO (SPA NCS))))" --tones "Objective"
 # python -m pressgloss --operation translate --daide "FRM (ENG) (FRA ITA) (PRP (AND (PCE (FRA ITA)) (XDO ((ENG AMY LVP) RTO YOR))))" --tones "Objective"
 # python -m pressgloss --operation translate --daide "FRM (FRA) (ENG) (PRP (XDO ((ENG AMY LVP) MTO YOR)))" --tones "Objective,Expert"
 # python -m pressgloss --operation test --daide "FRM ( ENG) (FRA  ITA) (PRP (PCE (FRA ITA) ))"
@@ -90,13 +91,12 @@ def main(): # type: () -> None
     interestinggames = GAMELOG.analyzebackup(lesArgs.input)
     for curgame in interestinggames:
       GAMELOG.prettifygamefile(curgame, curgame)
+  elif lesArgs.operation == 'sh2daide':
+    daide = PRESSGLOSS.shorthand2daide(lesArgs.shorthand)
+    print(daide)
   elif lesArgs.operation == 'test':
-    print(helpers.listOfPowers(['AUS'], '', []))
-    print(helpers.listOfPowers(['AUS'], '', ['AUS']))
-    print(helpers.listOfPowers(['AUS'], '', ['FRA']))
-    print(helpers.listOfPowers(['AUS'], '', ['FRA', 'AUS']))
-    print(helpers.listOfPowers(['FRA', 'AUS'], '', ['FRA', 'AUS']))
-    print(helpers.listOfPowers(['FRA', 'AUS'], '', ['AUS']))
+    print(PRESSGLOSS.shorthand2daide('ENG', 'A WAL S F MAO - IRI'))
+    print(PRESSGLOSS.shorthand2daide('ENG', 'A WAL S F MAO - IRI', 'FRA'))
 
 if __name__ == '__main__':
   main()

--- a/pressgloss/core.py
+++ b/pressgloss/core.py
@@ -3810,7 +3810,7 @@ def messageFactory(utterance, container, daidelists): # type: (PressUtterance, P
     return PressSupportMove(utterance, container, daidelists)
   elif len(daidelists) == 5 and daidelists[1] == 'CVY' and daidelists[3] == 'CTO':
     return PressConvoy(utterance, container, daidelists)
-  elif len(daidelists) == 5 and daidelists[1] == 'CVY' and daidelists[3] == 'VIA':
+  elif len(daidelists) == 5 and daidelists[1] == 'CTO' and daidelists[3] == 'VIA':
     return PressConvoyVia(utterance, container, daidelists)
   elif len(daidelists) == 3 and daidelists[1] == 'RTO':
     return PressRetreat(utterance, container, daidelists)
@@ -3917,3 +3917,22 @@ def daide2gloss(daide, tones=None): # type: (str, []) -> str
   utterance = PressUtterance(daide, tones)
   utterance.formenglish()
   return utterance.english
+
+def shorthand2daide(owner, shorthand, thirdparty=''): # type: (str, str, str) -> str
+  """
+  Translates a Paquette-style move shorthand to a DAIDE XDO expression
+
+  :param owner: the trigram of the owner of the units mentioned in the shorthand
+  :type owner: str
+  :param shorthand: a space-delimited move shorthand such as F NWG C A NWY - EDI or A IRO R MAO
+  :type shorthand: str
+  :param thirdparty: trigram of the owner of a supported or convoyed unit if the supported unit is of a different power than the owner
+  :type thirdparty: str
+
+  :return: a DAIDE XDO expression representing the move such as XDO ((ENG FLT NWG) CVY (FRA AMY NWY) CTO EDI) or XDO ((ENG AMY IRO) RTO MAO)
+
+  """
+
+  shlists = helpers.shorthand2lists(owner, shorthand, thirdparty)
+  pme = PressMoveExecute(None, None, shlists)
+  return pme.formDAIDE()

--- a/pressgloss/gamelog.py
+++ b/pressgloss/gamelog.py
@@ -53,7 +53,6 @@ def analyzebackup(inpath): # type: (str) -> []
               curtones = curtonesstr.split(',')
               for curtone in curtones:
                 tonesused[curtone] += 1
-              print('Trying to process: ' + curmessage['daide'] + ': ' + str(curtones))
               curdaide = PRESSGLOSS.PressUtterance(curmessage['daide'], curtones)
               messages += 1
               if 'Ahem' in curdaide.english:
@@ -63,8 +62,34 @@ def analyzebackup(inpath): # type: (str) -> []
                 if curdaide.content.details is not None:
                   daideoperators[curdaide.content.details.operator] += 1
             if len(messagelist) > 0 and curfullpath not in retset:
-              print('Found messages in ' + curfullpath)
               retset.add(curfullpath)
+        if 'status' in curgame and curgame['status'] == 'completed':
+          print(curfullpath + ' completed')
+          print('  won by ' + str(curgame['victory']))
+          print('  outcome: ' + str(curgame['outcome']))
+        else:
+          print(curfullpath + ' in progress')
+        ctrl2powers = {}
+        for curpower, powerinfo in curgame['powers'].items():
+          print(curpower + ':')
+          dummyct = 0
+          for ctrlid, ctrlname in powerinfo['controller'].items():
+            cleanname = ctrlname.strip().lower()
+            if cleanname == 'dummy':
+              dummyct += 1
+            if cleanname not in ctrl2powers:
+              ctrl2powers[cleanname] = set()
+            ctrl2powers[cleanname].add(curpower)
+          if len(powerinfo['controller']) == dummyct and dummyct > 0:
+            print('  Dummy')
+          elif dummyct > 0:
+            print('  Hybrid')
+          elif dummyct == 0:
+            print('  All Human')
+          else:
+            print('  Odd controller data')
+        print(str(ctrl2powers))
+        print('  ' + str(len(curgame['order_history'])) + ' seasons played')
 
   print('Press found in ' + str(len(retset)) + ' games.')
   print('  ' + str(messages) + ' messages found.')

--- a/pressgloss/resources/reference.csv
+++ b/pressgloss/resources/reference.csv
@@ -53,7 +53,10 @@ MUN,Province,Munich,Munich,Munich,Munchner,0,0,1
 NAF,Province,North Africa,North Africa,North Africa,North African,0,1,0
 NAO,Province,the North Atlantic,the North Atlantic,the North Atlantic,North Atlantic,1,0,0
 NAP,Province,Naples,Naples,Naples,Neapolitan,0,1,1
-NCS,Province,the North Coast,the North Coast,the North Coast,North Coaster,0,1,0
+SPANCS,Province,the North Coast of Spain,the North Coast of Spain,the North Coast of Spain,Spanish North Coaster,0,1,0
+SPASCS,Province,the South Coast of Spain,the South Coast of Spain,the South Coast of Spain,Spanish South Coaster,0,1,0
+STPNCS,Province,the North Coast of St. Petersburg,the North Coast of St. Petersburg,the North Coast of St. Petersburg,St. Petersburg North Coaster,0,1,0
+STPSCS,Province,the South Coast of St. Petersburg,the South Coast of St. Petersburg,the South Coast of St. Petersburg,St. Petersburg South Coaster,0,1,0
 NTH,Province,the North Sea,the North Sea,the North Sea,North Sea,1,0,0
 NWG,Province,the Norwegian Sea,the Norwegian Sea,the Norwegian Sea,Norwegian Sea,1,0,0
 NWY,Province,Norway,Norway,Norway,Norwegian,0,1,1
@@ -86,3 +89,4 @@ WAL,Province,Wales,Wales,Wales,Welsh,0,1,0
 WAR,Province,Warsaw,Warsaw,Warsaw,Varsovian,0,0,1
 WES,Province,the Western Mediterranean,the Western Mediterranean,the Western Mediterranean,Western Mediterranean,1,0,0
 YOR,Province,Yorkshire,Yorkshire,Yorkshire,Yorkish,0,1,0
+UNK,Province,Unknown,Unknown,Unknown,Unknown,0,0,0

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -8,6 +8,16 @@ import unittest
 import pressgloss.core as PRESSGLOSS
 import pressgloss.helpers as helpers
 
+shorthandtests = {'F NWG C A NWY - EDI': 'XDO ((ENG FLT NWG) CVY (FRA AMY NWY) CTO EDI)',
+                  'A IRO R MAO': 'XDO ((ENG AMY IRO) RTO MAO)',
+                  'A IRO D': 'XDO ((ENG AMY IRO) DSB)',
+                  'A LON B': 'XDO ((ENG AMY LON) BLD)',
+                  'A LON H': 'XDO ((ENG AMY LON) HLD)',
+                  'A IRI - MAO VIA': 'XDO ((ENG AMY IRI) CTO MAO VIA (UNK))',
+                  'A WAL S F MAO - IRI': 'XDO ((ENG AMY WAL) SUP (FRA FLT MAO) MTO IRI)',
+                  'A WAL S F LON': 'XDO ((ENG AMY WAL) SUP (FRA FLT LON))',
+                  'F IRI - MAO': 'XDO ((ENG FLT IRI) MTO MAO)'}
+
 parsetests = ['FRM (ENG) (FRA  ITA) (PRP (PCE (FRA ITA) ))',
               'FRM (ENG) (FRA ITA) (PRP (PCE (FRA ITA) ))',
               'FRM (ENG) (FRA  ITA) (PRP (PCE (FRA ITA)))',
@@ -239,6 +249,10 @@ soloexprs = [
 moveexprs = [
               'FRM (FRA) (ENG) (PRP (XDO ((ENG AMY LVP) HLD)))',
               'FRM (FRA) (ENG) (PRP (XDO ((ENG AMY LVP) MTO YOR)))',
+              'FRM (FRA) (ENG) (PRP (XDO ((ENG AMY LVP) MTO (SPA NCS))))',
+              'FRM (FRA) (ENG) (PRP (XDO ((ENG AMY LVP) MTO (SPA SCS))))',
+              'FRM (FRA) (ENG) (PRP (XDO ((ENG AMY LVP) MTO (STP NCS))))',
+              'FRM (FRA) (ENG) (PRP (XDO ((ENG AMY LVP) MTO (STP SCS))))',
               'FRM (FRA) (ENG) (PRP (DMZ (FRA ENG) (LVP YOR)))',
               'FRM (FRA) (ENG) (PRP (DMZ (FRA ENG ITA) (LVP YOR)))',
               'FRM (FRA) (ENG) (PRP (XDO ((ENG AMY LVP) SUP (FRA AMY YOR) MTO LON)))',
@@ -459,6 +473,12 @@ class PowerListTest(unittest.TestCase):
     self.assertEqual(helpers.listOfPowers(['AUS'], '', ['AUS', 'FRA']), 'Austria-Hungary')
     self.assertEqual(helpers.listOfPowers(['AUS', 'FRA'], '', ['AUS', 'FRA']), 'you two')
     self.assertEqual(helpers.listOfPowers(['AUS', 'FRA'], '', ['AUS']), 'you and France')
+
+class ShorthandTest(unittest.TestCase):
+  """ Tests conversion of Paquette shorthand to DAIDE """
+  def test(self):
+    for cursh, curdaide in shorthandtests.items():
+      self.assertEqual(PRESSGLOSS.shorthand2daide('ENG', cursh, 'FRA'), curdaide)
 
 class ParseTest(unittest.TestCase):
   """ Tests parsing of various quasi-compliant DAIDE strings. """


### PR DESCRIPTION
The parser creates the same kind of Python lists out of the shorthand that it uses for DAIDE strings.  It then initializes an XDO object with those lists so that we can produce both DAIDE and English glosses of the shorthand.

Also added support for North and South coasts of Spain and St. Petersburg

Added unit tests for shorthand